### PR TITLE
Decode results before loading json.

### DIFF
--- a/gripql/python/gripql/query.py
+++ b/gripql/python/gripql/query.py
@@ -272,7 +272,7 @@ class Query:
 
         for result in response.iter_lines(chunk_size=None):
             try:
-                result_dict = json.loads(result)
+                result_dict = json.loads(result.decode())
             except Exception as e:
                 logger.error("Failed to decode: %s", result)
                 raise e


### PR DESCRIPTION
This is a simple but effective (in the cases I have tested) method to allow python 3.5-3.6 compatibility, a la #158.